### PR TITLE
softDestroy wrong callback type check

### DIFF
--- a/src/soft-delete.js
+++ b/src/soft-delete.js
@@ -43,8 +43,8 @@ export default (Model, { deletedAt = 'deletedAt', scrub = false }) => {
     const callback = (cb === undefined && typeof options === 'function') ? options : cb;
 
     return this.updateAttributes({ ...scrubbed, [deletedAt]: new Date() })
-      .then(result => (typeof cb === 'function') ? callback(null, result) : result)
-      .catch(error => (typeof cb === 'function') ? callback(error) : Promise.reject(error));
+      .then(result => (typeof callback === 'function') ? callback(null, result) : result)
+      .catch(error => (typeof callback === 'function') ? callback(error) : Promise.reject(error));
   };
 
   Model.prototype.remove = Model.prototype.destroy;


### PR DESCRIPTION
Hi there,

In the softDestroy function, `cb` typeof is used instead of `callback` one.

When options is the callback function, cb is undefined and result in a lost cb.

Don't hesitate to discuss 👍 