### PR TITLE
Fixed queryNotDeleted query

### DIFF
--- a/src/soft-delete.js
+++ b/src/soft-delete.js
@@ -51,7 +51,7 @@ export default (Model, { deletedAt = 'deletedAt', scrub = false }) => {
   Model.prototype.delete = Model.prototype.destroy;
 
   // Emulate default scope but with more flexibility.
-  const queryNonDeleted = {[deletedAt]: null};
+  const queryNonDeleted = {[deletedAt]: {lt: 1}};
 
   const _findOrCreate = Model.findOrCreate;
   Model.findOrCreate = function findOrCreateDeleted(query = {}, ...rest) {


### PR DESCRIPTION
In loopback 3, loopback-datasource-juggler/lib/geo.js line 29 causes an error when 

```
const queryNonDeleted = {[deletedAt]: null};
```